### PR TITLE
Aero backdrop accuracy changes 

### DIFF
--- a/Common/Common.cpp
+++ b/Common/Common.cpp
@@ -148,6 +148,32 @@ namespace MDWMBlurGlass
 		if (!ret.empty())
 			cfgData.blurmethod = (blurMethod)std::clamp(_wtoi(ret.data()), 0, 2);
 
+		// new - begin
+
+		ret = Utils::GetIniString(path, L"aero", L"PrimaryBalance");
+		if (!ret.empty())
+			cfgData.PrimaryBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 1.0);
+
+		ret = Utils::GetIniString(path, L"aero", L"Active_SecondaryBalance");
+		if (!ret.empty())
+			cfgData.Active_SecondaryBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 1.0);
+
+		ret = Utils::GetIniString(path, L"aero", L"Inactive_SecondaryBalance");
+		if (!ret.empty())
+			cfgData.Inactive_SecondaryBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 1.0);
+
+
+		ret = Utils::GetIniString(path, L"aero", L"Active_BlurBalance");
+		if (!ret.empty())
+			cfgData.Active_BlurBalance = (float)std::clamp(_wtof(ret.data()), -1.0, 1.0);
+
+		ret = Utils::GetIniString(path, L"aero", L"Inactive_BlurBalance");
+		if (!ret.empty())
+			cfgData.Inactive_BlurBalance = (float)std::clamp(_wtof(ret.data()), -1.0, 1.0);
+
+
+		// new - end
+
 		ret = Utils::GetIniString(path, L"config", L"effectType");
 		if (!ret.empty())
 		{
@@ -178,5 +204,7 @@ namespace MDWMBlurGlass
 		Utils::SetIniString(path, L"config", L"inactiveBlendColorDark", std::to_wstring(cfg.inactiveBlendColorDark));
 		Utils::SetIniString(path, L"config", L"blurMethod", std::to_wstring((int)cfg.blurmethod));
 		Utils::SetIniString(path, L"config", L"effectType", std::to_wstring((int)cfg.effectType));
+
+		// not on the gui... not sure if i should put the new entries here!
 	}
 }

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -51,6 +51,15 @@ namespace MDWMBlurGlass
 		float blurAmount = 20.f;
 		float customBlurAmount = 20.f;
 		float luminosityOpacity = 0.65f;
+
+		// these settings are optimal for the default Sky color from Windows 7
+
+		float PrimaryBalance = 0.08f;
+		float Active_SecondaryBalance = 0.43f;
+		float Inactive_SecondaryBalance = 0.43f;
+		float Active_BlurBalance = -0.125f;
+		float Inactive_BlurBalance = 0.365f;
+
 		COLORREF activeTextColor = 0xFF000000;
 		COLORREF inactiveTextColor = 0xFFB4B4B4;
 		COLORREF activeBlendColor = 0x64FFFFFF;
@@ -60,6 +69,7 @@ namespace MDWMBlurGlass
 		COLORREF inactiveTextColorDark = 0xFFB4B4B4;
 		COLORREF activeBlendColorDark = 0x64000000;
 		COLORREF inactiveBlendColorDark = 0x64000000;
+
 
 		blurMethod blurmethod = blurMethod::CustomBlur;
 		effectType effectType = effectType::Blur;

--- a/DWMBlurGlassExt/Section/BackdropMaterials.cpp
+++ b/DWMBlurGlassExt/Section/BackdropMaterials.cpp
@@ -26,7 +26,6 @@
 #include "../Effects/ExposureEffect.hpp"
 #include "BackdropMaterials.h"
 #include "CommonDef.h"
-
 #include <ranges>
 #include <Shlwapi.h>
 #pragma comment(lib, "Shlwapi.lib")
@@ -68,7 +67,7 @@ namespace MDWMBlurGlassExt
 		crossFadeEffect->SetSource(winrt::Windows::UI::Composition::CompositionEffectSourceParameter{ L"From" });
 		crossFadeEffect->SetDestination(winrt::Windows::UI::Composition::CompositionEffectSourceParameter{ L"To" });
 		crossFadeEffect->SetWeight(0);
-	
+
 		winrt::Windows::UI::Composition::CompositionEffectBrush crossFadeEffectBrush
 		{
 			compositor.CreateEffectFactory(
@@ -80,7 +79,7 @@ namespace MDWMBlurGlassExt
 		crossFadeEffectBrush.SetSourceParameter(L"To", to);
 		return crossFadeEffectBrush;
 	}
-	
+
 	winrt::Windows::UI::Composition::ScalarKeyFrameAnimation CBackdropResources::CreateCrossFadeAnimation(
 		const winrt::Windows::UI::Composition::Compositor& compositor,
 		winrt::Windows::Foundation::TimeSpan const& crossfadeTime
@@ -121,74 +120,74 @@ namespace MDWMBlurGlassExt
 	) try
 	{
 		THROW_IF_FAILED(EnsureNoiceSurfaceBrush());
-	
+
 		auto tintColorEffect{ winrt::make_self<ColorSourceEffect>() };
 		tintColorEffect->SetName(L"TintColor");
 		tintColorEffect->SetColor(tintColor);
-	
+
 		auto tintOpacityEffect{ winrt::make_self<OpacityEffect>() };
 		tintOpacityEffect->SetName(L"TintOpacity");
 		tintOpacityEffect->SetOpacity(tintOpacity);
 		tintOpacityEffect->SetInput(tintColorEffect);
-	
-		auto gaussianBlurEffect{ winrt::make_self<GaussianBlurEffect>()};
+
+		auto gaussianBlurEffect{ winrt::make_self<GaussianBlurEffect>() };
 		gaussianBlurEffect->SetName(L"Blur");
 		gaussianBlurEffect->SetBorderMode(D2D1_BORDER_MODE_HARD);
 		gaussianBlurEffect->SetBlurAmount(blurAmount);
 		winrt::Windows::UI::Composition::CompositionEffectSourceParameter backdropEffectSourceParameter{ L"Backdrop" };
 		gaussianBlurEffect->SetInput(backdropEffectSourceParameter);
-	
+
 		auto luminosityColorEffect{ winrt::make_self<ColorSourceEffect>() };
 		luminosityColorEffect->SetName(L"LuminosityColor");
 		luminosityColorEffect->SetColor(luminosityColor);
-	
+
 		auto luminosityOpacityEffect{ winrt::make_self<OpacityEffect>() };
 		luminosityOpacityEffect->SetName(L"LuminosityOpacity");
 		luminosityOpacityEffect->SetOpacity(luminosityOpacity);
 		luminosityOpacityEffect->SetInput(luminosityColorEffect);
-	
+
 		auto luminosityBlendEffect{ winrt::make_self<BlendEffect>() };
 		// NOTE: There is currently a bug where the names of BlendEffectMode::Luminosity and BlendEffectMode::Color are flipped->
 		// This should be changed to Luminosity when/if the bug is fixed->
 		luminosityBlendEffect->SetBlendMode(D2D1_BLEND_MODE_COLOR);
 		luminosityBlendEffect->SetBackground(gaussianBlurEffect);
 		luminosityBlendEffect->SetForeground(luminosityOpacityEffect);
-	
+
 		auto colorBlendEffect{ winrt::make_self<BlendEffect>() };
 		// NOTE: There is currently a bug where the names of BlendEffectMode::Luminosity and BlendEffectMode::Color are flipped->
 		// This should be changed to Color when/if the bug is fixed->
 		colorBlendEffect->SetBlendMode(D2D1_BLEND_MODE_LUMINOSITY);
 		colorBlendEffect->SetBackground(luminosityBlendEffect);
 		colorBlendEffect->SetForeground(tintOpacityEffect);
-	
+
 		auto noiseBorderEffect{ winrt::make_self<BorderEffect>() };
 		noiseBorderEffect->SetExtendX(D2D1_BORDER_EDGE_MODE_WRAP);
 		noiseBorderEffect->SetExtendY(D2D1_BORDER_EDGE_MODE_WRAP);
 		winrt::Windows::UI::Composition::CompositionEffectSourceParameter noiseEffectSourceParameter{ L"Noise" };
 		noiseBorderEffect->SetInput(noiseEffectSourceParameter);
-	
+
 		auto noiseOpacityEffect{ winrt::make_self<OpacityEffect>() };
 		noiseOpacityEffect->SetName(L"NoiseOpacity");
 		noiseOpacityEffect->SetOpacity(0.02f);
 		noiseOpacityEffect->SetInput(noiseBorderEffect);
-	
+
 		auto blendEffectOuter{ winrt::make_self<BlendEffect>() };
 		blendEffectOuter->SetBlendMode(D2D1_BLEND_MODE_MULTIPLY);
 		blendEffectOuter->SetBackground(colorBlendEffect);
 		blendEffectOuter->SetForeground(noiseOpacityEffect);
-	
+
 		auto effectBrush
-		{ 
+		{
 			compositor.CreateEffectFactory(
 				blendEffectOuter.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>()
-			).CreateBrush() 
+			).CreateBrush()
 		};
 		effectBrush.SetSourceParameter(L"Backdrop", compositor.CreateBackdropBrush());
 		effectBrush.SetSourceParameter(L"Noise", noiceBrush);
-	
+
 		return effectBrush;
 	}
-	catch(...) { return nullptr; }
+	catch (...) { return nullptr; }
 
 	HRESULT CAcrylicResources::EnsureNoiceSurfaceBrush() try
 	{
@@ -196,7 +195,7 @@ namespace MDWMBlurGlassExt
 		{
 			return S_OK;
 		}
-	
+
 		auto compositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
 		winrt::Windows::UI::Composition::CompositionGraphicsDevice graphicsDevice{ nullptr };
 		THROW_IF_FAILED(
@@ -214,7 +213,7 @@ namespace MDWMBlurGlassExt
 			)
 		};
 		noiceBrush = compositor.CreateSurfaceBrush(compositionSurface);
-	
+
 		wil::unique_hmodule wuxcModule{ LoadLibraryExW(L"Windows.UI.Xaml.Controls.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE) };
 		THROW_LAST_ERROR_IF_NULL(wuxcModule);
 		auto resourceHandle{ FindResourceW(wuxcModule.get(), MAKEINTRESOURCE(2000), RT_RCDATA) };
@@ -222,19 +221,19 @@ namespace MDWMBlurGlassExt
 		auto globalHandle{ LoadResource(wuxcModule.get(), resourceHandle) };
 		THROW_LAST_ERROR_IF_NULL(globalHandle);
 		auto cleanUp = wil::scope_exit([&]
-		{
-			if (globalHandle)
 			{
-				UnlockResource(globalHandle);
-				FreeResource(globalHandle);
-			}
-		});
+				if (globalHandle)
+				{
+					UnlockResource(globalHandle);
+					FreeResource(globalHandle);
+				}
+			});
 		DWORD resourceSize{ SizeofResource(wuxcModule.get(), resourceHandle) };
 		THROW_LAST_ERROR_IF(resourceSize == 0);
 		auto resourceAddress{ reinterpret_cast<PBYTE>(LockResource(globalHandle)) };
 		winrt::com_ptr<IStream> stream{ SHCreateMemStream(resourceAddress, resourceSize), winrt::take_ownership_from_abi };
 		THROW_LAST_ERROR_IF_NULL(stream);
-		
+
 		winrt::com_ptr<IWICImagingFactory2> wicFactory{ nullptr };
 		wicFactory.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetWICFactory());
 		winrt::com_ptr<IWICBitmapDecoder> wicDecoder{ nullptr };
@@ -255,7 +254,7 @@ namespace MDWMBlurGlassExt
 		);
 		winrt::com_ptr<IWICBitmap> wicBitmap{ nullptr };
 		THROW_IF_FAILED(wicFactory->CreateBitmapFromSource(wicConverter.get(), WICBitmapCreateCacheOption::WICBitmapNoCache, wicBitmap.put()));
-	
+
 		auto drawingSurfaceInterop{ compositionSurface.as<ABI::Windows::UI::Composition::ICompositionDrawingSurfaceInterop>() };
 		POINT offset = { 0, 0 };
 		winrt::com_ptr<ID2D1DeviceContext> d2dContext{ nullptr };
@@ -276,30 +275,30 @@ namespace MDWMBlurGlassExt
 		THROW_IF_FAILED(
 			drawingSurfaceInterop->EndDraw()
 		);
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT CAcrylicResources::EnsureAcrylicBrush()
+		HRESULT CAcrylicResources::EnsureAcrylicBrush()
 	{
 		if (interopDCompDevice.get() != DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice())
 		{
 			interopDCompDevice.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice());
-	
+
 			noiceBrush = nullptr;
 			ClearBrushResource();
 		}
 		if (
-			lightMode_Active_Brush && 
+			lightMode_Active_Brush &&
 			darkMode_Active_Brush &&
 			lightMode_Inactive_Brush &&
 			darkMode_Inactive_Brush
-		)
+			)
 		{
 			return S_OK;
 		}
-	
+
 		auto compositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
 		lightMode_Inactive_Brush = CreateBrush(
 			compositor,
@@ -333,7 +332,7 @@ namespace MDWMBlurGlassExt
 			g_configData.luminosityOpacity,
 			g_configData.customBlurAmount
 		);
-	
+
 		return S_OK;
 	}
 
@@ -348,21 +347,21 @@ namespace MDWMBlurGlassExt
 		auto tintColorEffect{ winrt::make_self<ColorSourceEffect>() };
 		tintColorEffect->SetName(L"TintColor");
 		tintColorEffect->SetColor(tintColor);
-	
+
 		auto tintOpacityEffect{ winrt::make_self<OpacityEffect>() };
 		tintOpacityEffect->SetName(L"TintOpacity");
 		tintOpacityEffect->SetOpacity(tintOpacity);
 		tintOpacityEffect->SetInput(tintColorEffect);
-	
+
 		auto luminosityColorEffect{ winrt::make_self<ColorSourceEffect>() };
 		luminosityColorEffect->SetName(L"LuminosityColor");
 		luminosityColorEffect->SetColor(luminosityColor);
-	
+
 		auto luminosityOpacityEffect{ winrt::make_self<OpacityEffect>() };
 		luminosityOpacityEffect->SetName(L"LuminosityOpacity");
 		luminosityOpacityEffect->SetOpacity(luminosityOpacity);
 		luminosityOpacityEffect->SetInput(luminosityColorEffect);
-	
+
 		auto luminosityBlendEffect{ winrt::make_self<BlendEffect>() };
 		// NOTE: There is currently a bug where the names of BlendEffectMode::Luminosity and BlendEffectMode::Color are flipped->
 		// This should be changed to Luminosity when/if the bug is fixed->
@@ -370,14 +369,14 @@ namespace MDWMBlurGlassExt
 		winrt::Windows::UI::Composition::CompositionEffectSourceParameter backdropEffectSourceParameter{ L"BlurredWallpaperBackdrop" };
 		luminosityBlendEffect->SetBackground(backdropEffectSourceParameter);
 		luminosityBlendEffect->SetForeground(luminosityOpacityEffect);
-	
+
 		auto colorBlendEffect{ winrt::make_self<BlendEffect>() };
 		// NOTE: There is currently a bug where the names of BlendEffectMode::Luminosity and BlendEffectMode::Color are flipped->
 		// This should be changed to Color when/if the bug is fixed->
 		colorBlendEffect->SetBlendMode(D2D1_BLEND_MODE_LUMINOSITY);
 		colorBlendEffect->SetBackground(luminosityBlendEffect);
 		colorBlendEffect->SetForeground(tintOpacityEffect);
-	
+
 		auto effectBrush
 		{
 			compositor.CreateEffectFactory(
@@ -385,7 +384,7 @@ namespace MDWMBlurGlassExt
 			).CreateBrush()
 		};
 		effectBrush.SetSourceParameter(L"BlurredWallpaperBackdrop", compositor.TryCreateBlurredWallpaperBackdropBrush());
-	
+
 		return effectBrush;
 	}
 	catch (...) { return nullptr; }
@@ -395,7 +394,7 @@ namespace MDWMBlurGlassExt
 		if (interopDCompDevice.get() != DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice())
 		{
 			interopDCompDevice.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice());
-	
+
 			ClearBrushResource();
 		}
 		if (
@@ -403,11 +402,11 @@ namespace MDWMBlurGlassExt
 			darkMode_Active_Brush &&
 			lightMode_Inactive_Brush &&
 			darkMode_Inactive_Brush
-		)
+			)
 		{
 			return S_OK;
 		}
-	
+
 		auto compositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
 		lightMode_Inactive_Brush = CreateBrush(
 			compositor,
@@ -437,52 +436,81 @@ namespace MDWMBlurGlassExt
 			GetFloatAlpha(g_configData.activeBlendColorDark),
 			g_configData.luminosityOpacity
 		);
-	
+
 		return S_OK;
 	}
 
 	winrt::Windows::UI::Composition::CompositionBrush CAeroResources::CreateBrush(
 		const winrt::Windows::UI::Composition::Compositor& compositor,
 		const winrt::Windows::UI::Color& tintColor,
-		float tintOpacity,
-		float exposureAmount,
-		float blurAmount
+		float colorBalance,
+		float glowBalance,
+		float blurAmount,
+		float blurBalance
 	)
 	{
-		auto tintColorEffect{ winrt::make_self<ColorSourceEffect>() };
-		tintColorEffect->SetName(L"TintColor");
-		tintColorEffect->SetColor(tintColor);
-	
-		auto tintOpacityEffect{ winrt::make_self<OpacityEffect>() };
-		tintOpacityEffect->SetName(L"TintOpacity");
-		tintOpacityEffect->SetOpacity(tintOpacity);
-		tintOpacityEffect->SetInput(tintColorEffect);
-	
+		// New Aero backdrop recipe by @ALTaleX531 (https://github.com/ALTaleX531/AcrylicEverywhere), @aubymori (normal layer fixes)
+		// @kfh83 for porting to DWMBlurGlass and minor modifications
+
+		auto colorEffect{ winrt::make_self<ColorSourceEffect>() };
+		colorEffect->SetName(L"MainColor");
+		colorEffect->SetColor(tintColor);
+
+		auto colorOpacityEffect{ winrt::make_self<OpacityEffect>() };
+		colorOpacityEffect->SetName(L"MainColorOpacity");
+		colorOpacityEffect->SetInput(colorEffect);
+		colorOpacityEffect->SetOpacity(colorBalance);
+
+		auto glowColorEffect{ winrt::make_self<ColorSourceEffect>() };
+		glowColorEffect->SetName(L"GlowColor");
+		glowColorEffect->SetColor(tintColor);
+
+		auto glowOpacityEffect{ winrt::make_self<OpacityEffect>() };
+		glowOpacityEffect->SetName(L"GlowColorOpacity");
+		glowOpacityEffect->SetInput(glowColorEffect);
+		glowOpacityEffect->SetOpacity(glowBalance);
+
+		auto blurredBackdropBalanceEffect{ winrt::make_self<ExposureEffect>() };
+		blurredBackdropBalanceEffect->SetName(L"BlurBalance");
+		blurredBackdropBalanceEffect->SetExposure(blurBalance);
+
 		auto gaussianBlurEffect{ winrt::make_self<GaussianBlurEffect>() };
 		gaussianBlurEffect->SetName(L"Blur");
 		gaussianBlurEffect->SetBorderMode(D2D1_BORDER_MODE_HARD);
 		gaussianBlurEffect->SetBlurAmount(blurAmount);
-		winrt::Windows::UI::Composition::CompositionEffectSourceParameter backdropEffectSourceParameter{ L"Backdrop" };
-		gaussianBlurEffect->SetInput(backdropEffectSourceParameter);
-	
-		auto exposureEffect{ winrt::make_self<ExposureEffect>() };
-		exposureEffect->SetName(L"Exposure");
-		exposureEffect->SetExposure(exposureAmount);
-		exposureEffect->SetInput(gaussianBlurEffect);
-	
+		gaussianBlurEffect->SetInput(winrt::Windows::UI::Composition::CompositionEffectSourceParameter{ L"Backdrop" });
+		
+		blurredBackdropBalanceEffect->SetInput(gaussianBlurEffect);
+
+		auto colorBlendEffect{ winrt::make_self<BlendEffect>() };
+		colorBlendEffect->SetBlendMode(D2D1_BLEND_MODE_MULTIPLY);
+		colorBlendEffect->SetBackground(blurredBackdropBalanceEffect);
+		colorBlendEffect->SetForeground(colorOpacityEffect);
+
+		auto colorBalanceEffect{ winrt::make_self<ExposureEffect>() };
+		colorBalanceEffect->SetName(L"ColorBalance");
+		colorBalanceEffect->SetExposure(colorBalance / 10.f);
+		colorBalanceEffect->SetInput(colorBlendEffect);
+
 		auto compositeEffect{ winrt::make_self<CompositeStepEffect>() };
+		compositeEffect->SetName(L"Composite");
 		compositeEffect->SetCompositeMode(D2D1_COMPOSITE_MODE_SOURCE_OVER);
-		compositeEffect->SetDestination(exposureEffect);
-		compositeEffect->SetSource(tintOpacityEffect);
-	
+		compositeEffect->SetDestination(colorBalanceEffect);
+		compositeEffect->SetSource(glowOpacityEffect);
+
+		auto glowBalanceEffect{ winrt::make_self<ExposureEffect>() };
+		glowBalanceEffect->SetName(L"GlowBalance");
+		glowBalanceEffect->SetExposure(glowBalance / 10.f);
+		glowBalanceEffect->SetInput(compositeEffect);
+
 		auto effectBrush
 		{
 			compositor.CreateEffectFactory(
-				compositeEffect.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>()
+				glowBalanceEffect.as<winrt::Windows::Graphics::Effects::IGraphicsEffect>()
 			).CreateBrush()
 		};
 		effectBrush.SetSourceParameter(L"Backdrop", compositor.CreateBackdropBrush());
-	
+
 		return effectBrush;
 	}
 
@@ -491,7 +519,7 @@ namespace MDWMBlurGlassExt
 		if (interopDCompDevice.get() != DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice())
 		{
 			interopDCompDevice.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice());
-	
+
 			ClearBrushResource();
 		}
 		if (
@@ -503,37 +531,43 @@ namespace MDWMBlurGlassExt
 		{
 			return S_OK;
 		}
-	
+
+
 		auto compositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
+
 		lightMode_Inactive_Brush = CreateBrush(
 			compositor,
 			MakeWinrtColor(g_configData.inactiveBlendColor, true),
-			GetFloatAlpha(g_configData.inactiveBlendColor),
-			onlyBlur ? 0.f : 0.15f,
-			g_configData.customBlurAmount
+			g_configData.Inactive_SecondaryBalance,		// this controls the multiply layer intensity.
+			g_configData.PrimaryBalance * 0.4f,			// aero formula calls for 40% of the active opacity on the normal layer... so i'm reflecting it here
+			g_configData.customBlurAmount,
+			g_configData.Inactive_BlurBalance			// intensity of "overexposure" effect.
 		);
 		darkMode_Inactive_Brush = CreateBrush(
 			compositor,
 			MakeWinrtColor(g_configData.inactiveBlendColorDark, true),
-			GetFloatAlpha(g_configData.inactiveBlendColorDark),
-			onlyBlur  ? 0.f : -0.15f,
-			g_configData.customBlurAmount
+			g_configData.Inactive_SecondaryBalance,		// this controls the multiply layer intensity.	
+			g_configData.PrimaryBalance * 0.4f,			//aero formula calls for 40% of the active opacity on the normal layer... so i'm reflecting it here
+			g_configData.customBlurAmount,	
+			g_configData.Inactive_BlurBalance			// intensity of "overexposure" effect.
 		);
 		lightMode_Active_Brush = CreateBrush(
 			compositor,
 			MakeWinrtColor(g_configData.activeBlendColor, true),
-			GetFloatAlpha(g_configData.activeBlendColor),
-			0.0f,
-			g_configData.customBlurAmount
+			g_configData.Active_SecondaryBalance,		// this controls the multiply layer intensity.
+			g_configData.PrimaryBalance,				// this controls the normal layer intensity.
+			g_configData.customBlurAmount,
+			g_configData.Active_BlurBalance				// intensity of "overexposure" effect.
 		);
 		darkMode_Active_Brush = CreateBrush(
 			compositor,
 			MakeWinrtColor(g_configData.activeBlendColorDark, true),
-			GetFloatAlpha(g_configData.activeBlendColorDark),
-			0.0f,
-			g_configData.customBlurAmount
+			g_configData.Active_SecondaryBalance,		// this controls the multiply layer intensity.
+			g_configData.PrimaryBalance,				// this controls the normal layer intensity.
+			g_configData.customBlurAmount,
+			g_configData.Active_BlurBalance				// intensity of "overexposure" effect.
 		);
-	
+
 		return S_OK;
 	}
 
@@ -542,14 +576,14 @@ namespace MDWMBlurGlassExt
 		if (interopDCompDevice.get() != DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice())
 		{
 			interopDCompDevice.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice());
-	
+
 			drawingSurface = nullptr;
 		}
 		if (drawingSurface)
 		{
 			return S_OK;
 		}
-	
+
 		auto compositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
 		winrt::Windows::UI::Composition::CompositionGraphicsDevice graphicsDevice{ nullptr };
 		THROW_IF_FAILED(
@@ -558,7 +592,7 @@ namespace MDWMBlurGlassExt
 				reinterpret_cast<ABI::Windows::UI::Composition::ICompositionGraphicsDevice**>(winrt::put_abi(graphicsDevice))
 			)
 		);
-	
+
 		{
 			GetModuleFileName(wil::GetModuleInstanceHandle(), filePath, MAX_PATH);
 			PathCchRemoveFileSpec(filePath, MAX_PATH);
@@ -566,15 +600,15 @@ namespace MDWMBlurGlassExt
 		}
 		wil::unique_hfile file{ CreateFileW(filePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, 0) };
 		THROW_LAST_ERROR_IF(!file.is_valid());
-	
+
 		LARGE_INTEGER fileSize{};
 		THROW_IF_WIN32_BOOL_FALSE(GetFileSizeEx(file.get(), &fileSize));
-	
+
 		auto buffer{ std::make_unique<BYTE[]>(static_cast<size_t>(fileSize.QuadPart)) };
 		THROW_IF_WIN32_BOOL_FALSE(ReadFile(file.get(), buffer.get(), static_cast<DWORD>(fileSize.QuadPart), nullptr, nullptr));
-		winrt::com_ptr<IStream> stream{ SHCreateMemStream(buffer.get(), static_cast<UINT>(fileSize.QuadPart)), winrt::take_ownership_from_abi};
+		winrt::com_ptr<IStream> stream{ SHCreateMemStream(buffer.get(), static_cast<UINT>(fileSize.QuadPart)), winrt::take_ownership_from_abi };
 		THROW_LAST_ERROR_IF_NULL(stream);
-	
+
 		winrt::com_ptr<IWICImagingFactory2> wicFactory{ nullptr };
 		wicFactory.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetWICFactory());
 		winrt::com_ptr<IWICBitmapDecoder> wicDecoder{ nullptr };
@@ -595,8 +629,8 @@ namespace MDWMBlurGlassExt
 		);
 		winrt::com_ptr<IWICBitmap> wicBitmap{ nullptr };
 		THROW_IF_FAILED(wicFactory->CreateBitmapFromSource(wicConverter.get(), WICBitmapCreateCacheOption::WICBitmapNoCache, wicBitmap.put()));
-	
-		UINT width{0}, height{0};
+
+		UINT width{ 0 }, height{ 0 };
 		THROW_IF_FAILED(wicBitmap->GetSize(&width, &height));
 		drawingSurface = graphicsDevice.CreateDrawingSurface(
 			{ static_cast<float>(width), static_cast<float>(height) },
@@ -623,15 +657,15 @@ namespace MDWMBlurGlassExt
 		THROW_IF_FAILED(
 			drawingSurfaceInterop->EndDraw()
 		);
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CBackdropEffect::InitializeDCompAndVisual() try
+		HRESULT STDMETHODCALLTYPE CBackdropEffect::InitializeDCompAndVisual() try
 	{
 		interopDCompDevice.copy_from(DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice());
-	
+
 		THROW_IF_FAILED(
 			interopDCompDevice->CreateSharedResource(
 				IID_PPV_ARGS(interopCompositionTarget.put())
@@ -643,18 +677,18 @@ namespace MDWMBlurGlassExt
 		);
 		auto interopCompositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
 		spriteVisual = interopCompositor.CreateSpriteVisual();
-	
+
 		winrt::com_ptr<IDCompositionVisual2> dcompVisual{ nullptr };
 		THROW_IF_FAILED(interopDCompDevice->CreateVisual(dcompVisual.put()));
 		THROW_IF_FAILED(interopDCompDevice->Commit());
-	
+
 		auto interopVisual{ dcompVisual.as<DCompPrivate::IDCompositionVisualPartnerWinRTInterop>() };
 		interopVisual->GetVisualCollection().InsertAtTop(spriteVisual);
-	
+
 		THROW_IF_FAILED(interopCompositionTarget->SetRoot(dcompVisual.get()));
 		THROW_IF_FAILED(interopDCompDevice->Commit());
 		//THROW_IF_FAILED(interopDCompDevice->WaitForCommitCompletion());
-	
+
 		currentBrush = nullptr;
 		if (!udwmVisual)
 		{
@@ -665,12 +699,12 @@ namespace MDWMBlurGlassExt
 			udwmVisual->GetVisualProxy()->Release();
 			THROW_IF_FAILED(udwmVisual->InitializeFromSharedHandle(resourceHandle.get()));
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CBackdropEffect::InitializeVisualTreeClone(CBackdropEffect* backdrop) try
+		HRESULT STDMETHODCALLTYPE CBackdropEffect::InitializeVisualTreeClone(CBackdropEffect* backdrop) try
 	{
 		backdrop->currentSize = currentSize;
 		backdrop->useDarkMode = useDarkMode;
@@ -681,12 +715,12 @@ namespace MDWMBlurGlassExt
 		{
 			backdrop->udwmVisual->SetInsetFromParent(&margins);
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CBackdropEffect::UpdateBackdrop(DWM::CTopLevelWindow* topLevelWindow) try
+		HRESULT STDMETHODCALLTYPE CBackdropEffect::UpdateBackdrop(DWM::CTopLevelWindow* topLevelWindow) try
 	{
 		if (interopDCompDevice.get() != DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice())
 		{
@@ -736,7 +770,7 @@ namespace MDWMBlurGlassExt
 			{
 				udwmVisual->SetInsetFromParent(&margins);
 				RECT windowRect{};
-				THROW_HR_IF_NULL(E_INVALIDARG, topLevelWindow->GetActualWindowRect(&windowRect, false, true, true)); 
+				THROW_HR_IF_NULL(E_INVALIDARG, topLevelWindow->GetActualWindowRect(&windowRect, false, true, true));
 				newSize =
 				{
 					static_cast<float>(wil::rect_width(windowRect)) - 1.f,
@@ -748,18 +782,18 @@ namespace MDWMBlurGlassExt
 		{
 			currentSize = newSize;
 			spriteVisual.Size(currentSize);
-			THROW_IF_FAILED(udwmVisual->SetSize({static_cast<LONG>(currentSize.x), static_cast<LONG>(currentSize.y) }));
+			THROW_IF_FAILED(udwmVisual->SetSize({ static_cast<LONG>(currentSize.x), static_cast<LONG>(currentSize.y) }));
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CAcrylicBackdrop::UpdateBackdrop(DWM::CTopLevelWindow* topLevelWindow) try
+		HRESULT STDMETHODCALLTYPE CAcrylicBackdrop::UpdateBackdrop(DWM::CTopLevelWindow* topLevelWindow) try
 	{
 		THROW_IF_FAILED(CBackdropEffect::UpdateBackdrop(topLevelWindow));
 		auto newBrush{ s_sharedResources.ChooseIdealBrush(useDarkMode, windowActivated) };
-		if ( currentBrush != newBrush)
+		if (currentBrush != newBrush)
 		{
 			if (currentBrush)
 			{
@@ -786,16 +820,16 @@ namespace MDWMBlurGlassExt
 			}
 			currentBrush = newBrush;
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CAcrylicBackdrop::EnsureBackdropResources()
+		HRESULT STDMETHODCALLTYPE CAcrylicBackdrop::EnsureBackdropResources()
 	{
 		return s_sharedResources.EnsureAcrylicBrush();
 	}
-	
+
 	HRESULT STDMETHODCALLTYPE CMicaBackdrop::UpdateBackdrop(DWM::CTopLevelWindow* topLevelWindow) try
 	{
 		THROW_IF_FAILED(CBackdropEffect::UpdateBackdrop(topLevelWindow));
@@ -827,53 +861,31 @@ namespace MDWMBlurGlassExt
 			}
 			currentBrush = newBrush;
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CMicaBackdrop::EnsureBackdropResources()
+		HRESULT STDMETHODCALLTYPE CMicaBackdrop::EnsureBackdropResources()
 	{
 		return s_sharedResources.EnsureMicaBrush();
 	}
-	
+
 	HRESULT STDMETHODCALLTYPE CAeroBackdrop::UpdateBackdrop(DWM::CTopLevelWindow* topLevelWindow) try
 	{
 		THROW_IF_FAILED(CBackdropEffect::UpdateBackdrop(topLevelWindow));
 		auto newBrush{ s_sharedResources.ChooseIdealBrush(useDarkMode, windowActivated) };
 		if (currentBrush != newBrush)
 		{
-			if (currentBrush)
-			{
-				auto compositor{ interopDCompDevice.as<winrt::Windows::UI::Composition::Compositor>() };
-				auto crossfadeBrush
-				{
-					CBackdropResources::CreateCrossFadeEffectBrush(
-						compositor,
-						currentBrush, newBrush
-					)
-				};
-				crossfadeBrush.StartAnimation(
-					L"Crossfade.Weight",
-					CBackdropResources::CreateCrossFadeAnimation(
-						compositor,
-						crossFadeTime
-					)
-				);
-				spriteVisual.Brush(crossfadeBrush);
-			}
-			else
-			{
-				spriteVisual.Brush(newBrush);
-			}
+			spriteVisual.Brush(newBrush);
 			currentBrush = newBrush;
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
-	
-	HRESULT STDMETHODCALLTYPE CAeroBackdrop::EnsureBackdropResources()
+
+		HRESULT STDMETHODCALLTYPE CAeroBackdrop::EnsureBackdropResources()
 	{
 		return s_sharedResources.EnsureAeroBrush();
 	}
@@ -891,11 +903,11 @@ namespace MDWMBlurGlassExt
 		HWND hwnd{ topLevelWindow->GetData()->GetHWND() };
 		HMONITOR monitor{ MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
 		THROW_LAST_ERROR_IF_NULL(monitor);
-	
+
 		RECT monitorRect{};
 		MONITORINFO mi{ sizeof(MONITORINFO) };
 		THROW_IF_WIN32_BOOL_FALSE(GetMonitorInfoW(monitor, &mi));
-	
+
 		if (currentMonitor != monitor || !EqualRect(&currentMonitorRect, &mi.rcMonitor))
 		{
 			auto surfaceSize{ s_sharedResources.drawingSurface.SizeInt32() };
@@ -914,7 +926,7 @@ namespace MDWMBlurGlassExt
 					{
 						return static_cast<float>(wil::rect_height(mi.rcMonitor)) / static_cast<float>(surfaceSize.Height);
 					}
-	
+
 					return 1.f;
 				} ()
 			};
@@ -926,9 +938,9 @@ namespace MDWMBlurGlassExt
 				static_cast<float>(surfaceSize.Width) * scaleFactor,
 				static_cast<float>(surfaceSize.Height) * scaleFactor
 			};
-	
-			fixedOffset = 
-			{ 
+
+			fixedOffset =
+			{
 				(static_cast<float>(wil::rect_width(mi.rcMonitor)) - scaledSize.x) / 2.f,
 				(static_cast<float>(wil::rect_height(mi.rcMonitor)) - scaledSize.y) / 2.f
 			};
@@ -939,31 +951,31 @@ namespace MDWMBlurGlassExt
 		{
 			relativeOffset.x += static_cast<float>(currentWindowRect.left - windowRect.left);
 			relativeOffset.y += static_cast<float>(currentWindowRect.top - windowRect.top);
-			
+
 			MARGINS margins{};
 			topLevelWindow->GetBorderMargins(&margins);
 			glassSurfaceBrush.Offset(
 				winrt::Windows::Foundation::Numerics::float2
 				{
-					-static_cast<float>(windowRect.left - mi.rcMonitor.left) - 
+					-static_cast<float>(windowRect.left - mi.rcMonitor.left) -
 					static_cast<float>(relativeOffset.x * 0.1f) +
 					static_cast<float>(IsZoomed(hwnd) ? margins.cxLeftWidth : 0) +
 					fixedOffset.x,
-					-static_cast<float>(windowRect.top - mi.rcMonitor.top) - 
+					-static_cast<float>(windowRect.top - mi.rcMonitor.top) -
 					static_cast<float>(relativeOffset.y * 0.1f) +
 					static_cast<float>(IsZoomed(hwnd) ? margins.cyTopHeight : 0) +
-					fixedOffset.y	
+					fixedOffset.y
 				}
 			);
-	
+
 			currentWindowRect = windowRect;
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
-	HRESULT STDMETHODCALLTYPE CGlassReflectionBackdrop::EnsureBackdropResources() try
+		HRESULT STDMETHODCALLTYPE CGlassReflectionBackdrop::EnsureBackdropResources() try
 	{
 		THROW_IF_FAILED(s_sharedResources.EnsureGlassSurface());
 		if (!glassSurfaceBrush || interopDCompDevice.get() != DWM::CDesktopManager::s_pDesktopManagerInstance->GetDCompositionInteropDevice())
@@ -974,13 +986,13 @@ namespace MDWMBlurGlassExt
 			glassSurfaceBrush.HorizontalAlignmentRatio(0.f);
 			glassSurfaceBrush.VerticalAlignmentRatio(0.f);
 		}
-	
+
 		return S_OK;
 	}
 	CATCH_RETURN()
 
 
-	void CCompositedBackdrop::ConnectPrimaryBackdropToParent()
+		void CCompositedBackdrop::ConnectPrimaryBackdropToParent()
 	{
 		if (m_backdropEffect)
 		{
@@ -998,10 +1010,10 @@ namespace MDWMBlurGlassExt
 	}
 	void CCompositedBackdrop::ConnectBorderFillToParent()
 	{
-	
+
 	}
 
-	CCompositedBackdrop::CCompositedBackdrop(effectType type, bool glassReflection) : m_type{type}
+	CCompositedBackdrop::CCompositedBackdrop(effectType type, bool glassReflection) : m_type{ type }
 	{
 		if (os::buildNumber < 26020)
 		{
@@ -1011,11 +1023,11 @@ namespace MDWMBlurGlassExt
 		{
 			THROW_IF_FAILED(DWM::CContainerVisual::Create(m_visual.put()));
 		}
-	
+
 		UpdateBackdropType(m_type);
 		UpdateGlassReflection(glassReflection);
 		// ...
-	
+
 		MARGINS margins{ 0, 0, 0, 0 };
 		m_visual->SetInsetFromParent(&margins);
 		m_visual->SetDirtyChildren();
@@ -1032,13 +1044,13 @@ namespace MDWMBlurGlassExt
 			THROW_IF_FAILED(m_glassReflection->InitializeVisualTreeClone(backdrop->m_glassReflection.get()));
 		}
 		// ...
-	
+
 		if (backdrop->m_clipRgn)
 		{
 			backdrop->m_clipRgn.reset(CreateRectRgn(0, 0, 0, 0));
 			THROW_LAST_ERROR_IF_NULL(backdrop->m_clipRgn);
 			THROW_LAST_ERROR_IF(CombineRgn(backdrop->m_clipRgn.get(), m_clipRgn.get(), nullptr, RGN_COPY) == ERROR);
-	
+
 			wil::com_ptr<DWM::CRgnGeometryProxy> geometry{ nullptr };
 			THROW_IF_FAILED(
 				DWM::ResourceHelper::CreateGeometryFromHRGN(
@@ -1101,13 +1113,13 @@ namespace MDWMBlurGlassExt
 	void CCompositedBackdrop::UpdateBackdropType(effectType type)
 	{
 		m_type = type;
-	
+
 		if (m_backdropEffect)
 		{
 			THROW_IF_FAILED(m_visual->GetVisualCollection()->Remove(m_backdropEffect->udwmVisual.get()));
 			m_backdropEffect.reset();
 		}
-	
+
 		switch (m_type)
 		{
 		case effectType::Aero:
@@ -1122,7 +1134,7 @@ namespace MDWMBlurGlassExt
 		}
 		case effectType::Mica:
 		{
-			if(os::buildNumber >= 22000)
+			if (os::buildNumber >= 22000)
 				m_backdropEffect = std::make_unique<CMicaBackdrop>();
 			else
 				m_backdropEffect = std::make_unique<CAcrylicBackdrop>();
@@ -1132,7 +1144,7 @@ namespace MDWMBlurGlassExt
 			m_backdropEffect = std::make_unique<CAeroBackdrop>();
 			break;
 		}
-	
+
 		ConnectPrimaryBackdropToParent();
 	}
 
@@ -1147,7 +1159,7 @@ namespace MDWMBlurGlassExt
 			m_glassReflection->UpdateBackdrop(window);
 		}
 		// ...
-		
+
 		// Geometry changed
 		if (hrgn != m_clipRgn.get())
 		{
@@ -1156,7 +1168,7 @@ namespace MDWMBlurGlassExt
 				m_clipRgn.reset(CreateRectRgn(0, 0, 0, 0));
 				THROW_LAST_ERROR_IF_NULL(m_clipRgn);
 				CombineRgn(m_clipRgn.get(), hrgn, nullptr, RGN_COPY);
-	
+
 				wil::com_ptr<DWM::CRgnGeometryProxy> geometry{ nullptr };
 				THROW_IF_FAILED(
 					DWM::ResourceHelper::CreateGeometryFromHRGN(
@@ -1278,7 +1290,7 @@ namespace MDWMBlurGlassExt
 			CAcrylicBackdrop::s_sharedResources.ClearBrushResource();
 			break;
 		case effectType::Mica:
-			if(os::buildNumber >= 22000)
+			if (os::buildNumber >= 22000)
 				CMicaBackdrop::s_sharedResources.ClearBrushResource();
 			else
 				CAcrylicBackdrop::s_sharedResources.ClearBrushResource();

--- a/DWMBlurGlassExt/Section/BackdropMaterials.h
+++ b/DWMBlurGlassExt/Section/BackdropMaterials.h
@@ -73,14 +73,18 @@ namespace MDWMBlurGlassExt
 		);
 		HRESULT EnsureMicaBrush();
 	};
+
+	// bookmark
+
 	struct CAeroResources : CBackdropResources
 	{
 		comp::CompositionBrush CreateBrush(
 			const comp::Compositor& compositor,
 			const winrt::Windows::UI::Color& tintColor,
-			float tintOpacity,
-			float exposureAmount,
-			float blurAmount
+			float colorBalance,
+			float glowBalance,
+			float blurAmount,
+			float blurBalance
 		);
 		bool onlyBlur = false;
 		HRESULT EnsureAeroBrush();
@@ -133,7 +137,7 @@ namespace MDWMBlurGlassExt
 	{
 		static CAeroResources s_sharedResources;
 
-		CAeroBackdrop() { crossFadeTime = std::chrono::milliseconds{87}; }
+		CAeroBackdrop() { crossFadeTime = std::chrono::milliseconds{ 87 }; }
 		STDMETHOD(UpdateBackdrop)(DWM::CTopLevelWindow* topLevelWindow) override;
 		STDMETHOD(EnsureBackdropResources)() override;
 	};
@@ -159,9 +163,9 @@ namespace MDWMBlurGlassExt
 		std::unique_ptr<CBackdropEffect> m_backdropEffect{ nullptr };
 		std::unique_ptr<CGlassReflectionBackdrop> m_glassReflection{ nullptr };
 		DWM::CRgnGeometryProxy* m_borderGeometry{ nullptr };
-		winrt::com_ptr<DWM::CVisual> m_solidColorVisual{nullptr};
+		winrt::com_ptr<DWM::CVisual> m_solidColorVisual{ nullptr };
 		bool m_extendToBorders{ false };
-		
+
 		void ConnectPrimaryBackdropToParent();
 		void ConnectGlassReflectionToParent();
 		void ConnectBorderFillToParent();
@@ -183,7 +187,7 @@ namespace MDWMBlurGlassExt
 	class CBackdropManager
 	{
 	public:
-		std::shared_ptr<CCompositedBackdrop> GetOrCreateBackdrop(DWM::CTopLevelWindow* topLevelWindow,  bool createIfNecessary = false);
+		std::shared_ptr<CCompositedBackdrop> GetOrCreateBackdrop(DWM::CTopLevelWindow* topLevelWindow, bool createIfNecessary = false);
 		std::shared_ptr<CCompositedBackdrop> CreateWithGivenBackdrop(DWM::CTopLevelWindow* topLevelWindow, std::shared_ptr<CCompositedBackdrop> backdrop);
 		std::shared_ptr<CCompositedBackdrop> Remove(DWM::CTopLevelWindow* topLevelWindow);
 		void RefreshEffectConfig();


### PR DESCRIPTION
Originally by @ALTaleX531 for [AcrylicEverywhere](https://github.com/ALTaleX531/AcrylicEverywhere), with help of @aubymori and @ephemeralViolette (thx for the MiaoUI-less fork)

This'll probably need some work to adapt into the GUI (which i haven't done because MiaoUI is conveniently not included in the source for DWMBlurGlass...) considering i've added new options into config.ini (that are pretty important, mind):

```
[aero]
PrimaryBalance=0.0 		; Controls normal layer opacity. If you turn this up to 1 the window will be fully opaque, for example. Ranges from 0 to 1

Active_SecondaryBalance=0.0	; Controls the multiply layer intensity for active windows. Ranges from 0 to 1.
Inactive_SecondaryBalance=0.0	; Controls the multiply layer intensity for inactive windows. Ranges from 0 to 1.

Active_BlurBalance=-0.0	        ; Controls "overexposure" effect for active windows. Ranges from -1 to 1
Inactive_BlurBalance=0.0	; Controls "overexposure" effect for inactive windows. Ranges from -1 to 1 
```
(separated into aero category for my own sake, can be put into [config])


Here are some before/after pictures of the new mods.
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/9dd9b252-02c8-42e0-9e1d-3751e262bbcf)

And some comparisons between my mod and Windows 7:
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/3ee09b5d-d63c-4ed5-8fc4-4f071073f70f)

Of course, it isn't _perfect_ right now, but it's already miles better of what we already have and hopefully it can get even better.

Lastly, a sample of what it can look like (again, thx @ephemeralViolette for the MiaoUI-less fork of DWMBlurGlass):
[BlurGlass-ColorMod.zip](https://github.com/Maplespe/DWMBlurGlass/files/14736999/BlurGlass-ColorMod.zip)

Instructions should be in the README.txt provided, so please read before using.