### PR TITLE
Fix ColorBalance in config.ini being ineffective

### DIFF
--- a/DWMBlurGlassExt/Backdrops/AeroBackdrop.hpp
+++ b/DWMBlurGlassExt/Backdrops/AeroBackdrop.hpp
@@ -104,7 +104,7 @@ namespace MDWMBlurGlassExt
 			colorBalanceEffect->SetExposureAmount(colorBalance / 10.f);
 			colorBalanceEffect->SetInput(*compositeEffect);
 
-			auto effectBrush{ compositor.CreateEffectFactory(*glowBalanceEffect).CreateBrush() };
+			auto effectBrush{ compositor.CreateEffectFactory(*colorBalanceEffect).CreateBrush() };
 			if (hostBackdrop)
 			{
 				effectBrush.SetSourceParameter(L"Backdrop", compositor.CreateHostBackdropBrush());


### PR DESCRIPTION
Fixes issue #231:
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/20503117-053b-4d8a-bbaa-63bf5dba1ddf)
(ColorBalance set to 1.0, inactive is set to 0.032, proving it works now)

Here's a binary for those who want a fix:
[DWMBlurGlassExt.dll.zip](https://github.com/Maplespe/DWMBlurGlass/files/14781780/DWMBlurGlassExt.dll.zip)

