### PR TITLE
Add multi-session/multi-process support

### DIFF
--- a/DWMBlurGlass/Helper/Helper.cpp
+++ b/DWMBlurGlass/Helper/Helper.cpp
@@ -459,9 +459,10 @@ namespace MDWMBlurGlass
 		return bResult;
 	}
 
-	DWORD GetProcessId(std::wstring_view name)
+	DWORD GetProcessId(std::wstring_view name, DWORD index = 0)
 	{
 		PROCESSENTRY32W pe;
+		DWORD currIndex = -1;
 		HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
 		pe.dwSize = sizeof(PROCESSENTRY32W);
 		if (!Process32FirstW(hSnapshot, &pe))
@@ -471,7 +472,10 @@ namespace MDWMBlurGlass
 		{
 			if (_wcsicmp(pe.szExeFile, name.data()) == 0)
 			{
-				return pe.th32ProcessID;
+				if (++currIndex >= index)
+				{
+					return pe.th32ProcessID;
+				}
 			}
 		}
 		CloseHandle(hSnapshot);

--- a/DWMBlurGlass/Helper/Helper.h
+++ b/DWMBlurGlass/Helper/Helper.h
@@ -39,7 +39,7 @@ namespace MDWMBlurGlass
 	extern bool BrowseForFile(bool isOpen, bool multiple, const std::vector<COMDLG_FILTERSPEC>& filter,
 		HWND parentWnd, std::vector<std::wstring>& selectedFiles, std::wstring_view defExtName = L"");
 
-	extern DWORD GetProcessId(std::wstring_view name);
+	extern DWORD GetProcessId(std::wstring_view name, DWORD index = 0);
 
 	extern bool Inject(DWORD processId, std::wstring_view dllName, std::wstring& err);
 

--- a/DWMBlurGlass/MHostHelper.cpp
+++ b/DWMBlurGlass/MHostHelper.cpp
@@ -141,12 +141,19 @@ namespace MDWMBlurGlass
 			err = GetBaseLanguageString(L"symloadfail");
 			return false;
 		}
-		const bool ret = Inject(GetProcessId(L"dwm.exe"), Utils::GetCurrentDir() + L"\\DWMBlurGlassExt.dll", err);
-		if(ret)
-		{
-			/*BOOL enable = TRUE;
-			SystemParametersInfoW(SPI_SETGRADIENTCAPTIONS, 0, &enable, SPIF_SENDCHANGE);*/
-			PostMessageW(FindWindowW(L"Dwm", nullptr), WM_THEMECHANGED, 0, 0);
+		bool success = true;
+		for (DWORD index = 0;; index++) {
+			DWORD pid = GetProcessId(L"dwm.exe", index);
+			if (pid == 0)
+			{
+				break
+			}
+			if(Inject(pid, Utils::GetCurrentDir() + L"\\DWMBlurGlassExt.dll", err))
+			{
+				PostMessageW(FindWindowW(L"Dwm", nullptr), WM_THEMECHANGED, 0, 0);
+			} else {
+				success = false;
+			}
 		}
 		return ret;
 	}
@@ -158,13 +165,35 @@ namespace MDWMBlurGlass
 			err = ui->GetStringValue(L"symloadfail");
 			return false;
 		}
-		return Inject(GetProcessId(L"dwm.exe"), Utils::GetCurrentDir() + L"\\DWMBlurGlassExt.dll", err);
+		bool success = true;
+		for (DWORD index = 0;; index++) {
+			DWORD pid = GetProcessId(L"dwm.exe", index);
+			if (pid == 0)
+			{
+				break
+			}
+			if (!Inject(pid, Utils::GetCurrentDir() + L"\\DWMBlurGlassExt.dll", err)) {
+				success = false;
+			}
+		}
+		return sucesss;
 	}
 
 	bool ShutdownDWMExtension(std::wstring& err)
 	{
 		MHostNotify(MHostNotifyType::Shutdown);
-		return UnInject(GetProcessId(L"dwm.exe"), Utils::GetCurrentDir() + L"\\DWMBlurGlassExt.dll", err);
+		bool success = true;
+		for (DWORD index = 0;; index++) {
+			DWORD pid = GetProcessId(L"dwm.exe", index);
+			if (pid == 0)
+			{
+				break
+			}
+			if (!UnInject(pid, Utils::GetCurrentDir() + L"\\DWMBlurGlassExt.dll", err)) {
+				success = false;
+			}
+		}
+		return sucesss;
 	}
 
 	HWND FindMessageWnd(DWORD pid)
@@ -189,10 +218,17 @@ namespace MDWMBlurGlass
 
 	void MHostNotify(MHostNotifyType type)
 	{
-		HWND msgwnd = FindMessageWnd(GetProcessId(L"dwm.exe"));
-		if (!IsWindow(msgwnd)) return;
+		for (DWORD index = 0;; index++) {
+			DWORD pid = GetProcessId(L"dwm.exe", index);
+			if (pid == 0)
+			{
+				break
+			}
+			HWND msgwnd = FindMessageWnd(pid);
+			if (!IsWindow(msgwnd)) continue;
 
-		SendMessageW(msgwnd, WM_APP + 20, (WPARAM)type, 0);
+			SendMessageW(msgwnd, WM_APP + 20, (WPARAM)type, 0);
+		}
 	}
 }
 

--- a/DWMBlurGlass/MHostHelper.cpp
+++ b/DWMBlurGlass/MHostHelper.cpp
@@ -155,7 +155,7 @@ namespace MDWMBlurGlass
 				success = false;
 			}
 		}
-		return ret;
+		return sucesss;
 	}
 
 	bool LoadDWMExtension(std::wstring& err, Mui::XML::MuiXML* ui)


### PR DESCRIPTION
Currently, if multiple sessions are logged in, the oldest DWM process is injected into. This pr corrects it so that all running DWM processes are injected into.