### PR TITLE
Aero Backdrop Update v2

### DIFF
--- a/Common/Common.cpp
+++ b/Common/Common.cpp
@@ -154,20 +154,19 @@ namespace MDWMBlurGlass
 		ret = Utils::GetIniString(path, L"config", L"glassIntensity");
 		if (!ret.empty())
 			cfgData.glassIntensity = (float)std::clamp(_wtof(ret.data()), 0.0, 1.0);
-		ret = Utils::GetIniString(path, L"config.aero", L"activeColorBalance");
+		ret = Utils::GetIniString(path, L"config.aero", L"ColorizationColorBalance");
 		if (!ret.empty())
-			cfgData.activeColorBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 1.0);
-		ret = Utils::GetIniString(path, L"config.aero", L"inactiveColorBalance");
-		if (!ret.empty())
-			cfgData.inactiveColorBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 1.0);
+			cfgData.ColorizationColorBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 100.0);
 
-		ret = Utils::GetIniString(path, L"config.aero", L"activeBlurBalance");
+		ret = Utils::GetIniString(path, L"config.aero", L"ColorizationAfterglowBalance");
 		if (!ret.empty())
-			cfgData.activeBlurBalance = (float)std::clamp(_wtof(ret.data()), -1.0, 1.0);
-		ret = Utils::GetIniString(path, L"config.aero", L"inactiveBlurBalance");
+			cfgData.ColorizationAfterglowBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 100.0);
+
+		ret = Utils::GetIniString(path, L"config.aero", L"ColorizationBlurBalance");
 		if (!ret.empty())
-			cfgData.inactiveBlurBalance = (float)std::clamp(_wtof(ret.data()), -1.0, 1.0);
-		//
+			cfgData.ColorizationBlurBalance = (float)std::clamp(_wtof(ret.data()), 0.0, 100.0);
+
+		
 
 		ret = Utils::GetIniString(path, L"config", L"effectType");
 		if (!ret.empty())
@@ -203,10 +202,9 @@ namespace MDWMBlurGlass
 
 		// newly added params since 2.1.0
 		Utils::SetIniString(path, L"config", L"glassIntensity", std::to_wstring(cfg.glassIntensity));
-		Utils::SetIniString(path, L"config.aero", L"activeColorBalance", std::to_wstring(cfg.activeColorBalance));
-		Utils::SetIniString(path, L"config.aero", L"inactiveColorBalance", std::to_wstring(cfg.inactiveColorBalance));
-		Utils::SetIniString(path, L"config.aero", L"activeBlurBalance", std::to_wstring(cfg.activeBlurBalance));
-		Utils::SetIniString(path, L"config.aero", L"inactiveBlurBalance", std::to_wstring(cfg.inactiveBlurBalance));
+		Utils::SetIniString(path, L"config.aero", L"ColorizationColorBalance", std::to_wstring(cfg.ColorizationColorBalance));
+		Utils::SetIniString(path, L"config.aero", L"ColorizationAfterglowBalance", std::to_wstring(cfg.ColorizationAfterglowBalance));
+		Utils::SetIniString(path, L"config.aero", L"BlurBalance", std::to_wstring(cfg.ColorizationBlurBalance));
 
 		Utils::SetIniString(path, L"config", L"activeTextColor", std::to_wstring(cfg.activeTextColor));
 		Utils::SetIniString(path, L"config", L"inactiveTextColor", std::to_wstring(cfg.inactiveTextColor));

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -59,10 +59,9 @@ namespace MDWMBlurGlass
 
 		// these settings are optimal for the default Sky color from Windows 7
 		// newly added params since 2.1.0
-		float activeColorBalance = 0.08f;
-		float inactiveColorBalance = 0.032f;
-		float activeBlurBalance = -0.125f;
-		float inactiveBlurBalance = 0.365f;
+		float ColorizationColorBalance = 8.0f;
+		float ColorizationAfterglowBalance = 43.0f;
+		float ColorizationBlurBalance = 49.0f;
 
 		COLORREF activeTextColor = 0xFF000000;
 		COLORREF inactiveTextColor = 0xFFB4B4B4;


### PR DESCRIPTION
This PR should replicate Windows 7 aero shader a lot more closely than what we currently have, which is normal layer blended with a multiply layer with an exposure effect. This image should kinda explain how the chain works in Windows 7:

![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/23d76359-281a-4d43-87ac-84892a13bf10)

![behaviors](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/d05f1bea-14ce-41df-b8ee-2af4d66321a6)

![sky-values](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/94c5c809-2baa-42fd-9956-537eea2f0ec1)
_(win7 pics)_

In practice, you won't notice much difference from what is currently in version 2.1.1, but given the changes, you should now be able to use values from Windows 7 as the behavior is pretty much completely accurate:
```
[config.aero]
ColorizationColorBalance=8.0
ColorizationAfterglowBalance=43.0
ColorizationBlurBalance=49.0
```
_(settings relevant for the Sky color)_

Thus eliminating the need of any guesswork of sorts to get accurate settings. Since this also removes the need of the exposure effect, it should also fix inactive brightening up _anthing_ behind the window as opposted to relying on additive blending to do that:

![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/80239eaf-d710-4758-b93b-cfc891516486)
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/2a17f631-3d11-48ee-acb0-509a3bfad688)
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/39f69e1a-b2c5-41bc-9845-c0f8caa28f93)

Here's some comparison images between Windows 7 and the new shader (7 are the 2 top windows, 10 on bottom):

_Sky_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/55a581ce-bb60-48af-8ac9-03011b2ed7b4)

_Pumpkin_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/0f14f019-f3da-4e2b-bde6-5899eeae0e5b)

_Ruby_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/0643715b-c18e-4da1-91c6-2f777a30fae0)

_Fuchsia_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/4f901b52-3043-45c2-9e36-0c4e3d6687fc)

_Violet_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/06f3e213-18f7-494d-a3ad-bead9a395b71)

**EXTRA:** For those nitpicky enough, you probably noticed how the current shader looks too bright with the Sky color on the Harmony wallpaper. Here's what the new one looks like:

_Windows 10, new shader_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/c69d01ce-7b41-49f3-b8a5-b74be2ac9d81)

_Windows 10, current shader_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/889ef738-2efe-437a-9cac-6b6856d52b77)

_Windows 7_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/062c433c-bc60-40ef-9a47-bf2435882633)

_Windows 10, new shader_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/bb67f512-a077-4d4d-8e74-f5084b50853f)

_Windows 10, old shader_
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/630cdf06-5958-4e4c-a2ae-b60c2aeaac96)

You should notice it looks darker now.

The only issues i know of is it sometimes fails to apply properly to the taskbar, resulting in a monochromatic backdrop due to only the ColorizationAfterglow layer being present. This was already in 2.1.1, but it's more apparent here. When windows open/close you can see the backdrop becoming completely opaque/black:

_Said issue in the new shader. I think it's opaque like this because of the way im doing the balances (blending with a completely solid black backdrop)._
![image](https://github.com/Maplespe/DWMBlurGlass/assets/85626296/8cd96c6d-b319-4939-acb5-33d24788ba4e)


If anyone wants to test, here's a binary and relevant values for the default W7 colors:
[DWMBlurGlassExt.zip](https://github.com/Maplespe/DWMBlurGlass/files/15030212/DWMBlurGlassExt.zip)

```
Windows 7 Default color codes for DWMBlurGlass
Color name (#OriginalvalueinAARRGGBB) - ValueConvertedToAABBGGRRInBase10

Sky (#74B8FC) - 4294752372
Twilight (#0046AD) - 4289545728
Sea (#32CDCD)- 4291677490
Leaf (#14A600) - 4278232596
Lime (#97D937) - 4281850263
Sun (#FADC0E) - 4279164154
Pumpkin (#FF9C00)- 4278230271
Ruby (#CE0F0F) - 4279177166
Fuchsia (#FF0099) - 4288217343
Blush (#FCC7F8) - 4294494204
Violet (#6E3BA1) - 4288756590
Lavender (#8D5A94) - 4287912589
Taupe (#98844C) - 4283204760
Chocolate (#4F1B1B) - 4279966543
Slate (#555555) - 4283782485
Frost (#FCFCFC) - 4294769916

Windows 7 Default color values from Winaero Tweaker
Color name - (ColorizationColorBalance, ColorizationAfterglowBalance, ColorizationBlurBalance)

Sky - (8, 43, 49)
Twilight - (56, 11, 33)
Sea - (24, 32, 44)
Leaf - (5, 45, 50)
Lime - (5, 45, 50)
Sun - (5, 35, 60)
Pumpkin - (24, 32, 44)
Ruby - (56, 11, 33)
Fuchsia - (5, 45, 50)
Blush - (12, 40, 48)
Violet - (29, 29, 42)
Lavender - (5, 34, 61)
Taupe - (5, 45, 50)
Chocolate - (56, 11, 33)
Slate - (24, 32, 44)
Frost - (5, 35, 60)
```

Keep in mind, you'll have to replace:
```
[config.aero]
activeColorBalance=0.000000
inactiveColorBalance=0.000000
activeBlurBalance=0.000000
inactiveBlurBalance=0.000000
```
in your current config.ini with:
```
[config.aero]
ColorizationColorBalance=0.0
ColorizationAfterglowBalance=0.0
ColorizationBlurBalance=0.0
```

Finally, thanks 2 @TorutheRedFox for the lead on using Additive layering, @wackyideas for helping me figure out how the blur layer behaves on active/inactive and @aubymori for helping me get this thing working.
