### PR TITLE
Fix "waring" typo in winmain.cpp

### DIFF
--- a/DWMBlurGlass/winmain.cpp
+++ b/DWMBlurGlass/winmain.cpp
@@ -57,7 +57,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		{
 			MessageBoxW(nullptr,
 				Helper::M_ReplaceString(MDWMBlurGlass::GetBaseLanguageString(L"initfail0"), L"{path}", curpath).c_str(),
-				L"waring", MB_ICONWARNING | MB_TOPMOST);
+				L"Warning", MB_ICONWARNING | MB_TOPMOST);
 			return false;
 		}
 	}


### PR DESCRIPTION
This typo was brought to my attention by #368, so I thought to fix it.

I have no experience with c++, but I think this is just a string that can be edited without any functional change.

Sorry for the [Stereotypical PR](https://preview.redd.it/vflyausf5zp11.jpg?auto=webp&s=65c37fd59a54c0cf7f0fd28ac5ae66288b0e08aa) 😅