### PR TITLE
Fallback to parent language for missing translations and update Spanish locale

### DIFF
--- a/DWMBlurGlass/Helper/Helper.cpp
+++ b/DWMBlurGlass/Helper/Helper.cpp
@@ -87,14 +87,20 @@ namespace MDWMBlurGlass
 		return str;
 	}
 
-	std::wstring GetSystemLocalName()
+	std::pair<std::wstring, std::wstring> GetSystemLocaleAndParent()
 	{
 		WCHAR langName[LOCALE_NAME_MAX_LENGTH];
-		if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SNAME, langName, LOCALE_NAME_MAX_LENGTH)) 
+		if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SNAME, langName, LOCALE_NAME_MAX_LENGTH))
 		{
-			return langName;
+			std::wstring locale = langName;
+			auto pos = locale.find(L'-');
+			if (pos != std::wstring::npos)
+			{
+				return { locale, std::wstring(locale.substr(0, pos)) };
+			}
+			return { locale, locale };
 		}
-		return L"en-US";
+		return { L"en-US", L"en" };
 	}
 
 	std::wstring hrToStr(HRESULT hr)

--- a/DWMBlurGlass/Helper/Helper.h
+++ b/DWMBlurGlass/Helper/Helper.h
@@ -26,7 +26,7 @@ namespace MDWMBlurGlass
 
 	extern std::wstring ReadFileSting(std::wstring_view filePath);
 
-	extern std::wstring GetSystemLocalName();
+	std::pair<std::wstring, std::wstring> GetSystemLocaleAndParent();
 
 	extern bool InstallScheduledTasks(std::wstring& errinfo);
 

--- a/DWMBlurGlass/MainWindow.cpp
+++ b/DWMBlurGlass/MainWindow.cpp
@@ -38,13 +38,19 @@ namespace MDWMBlurGlass
 		if (!LoadDefualtUIStyle(ui))
 			return false;
 
-		if (!LoadLanguageString(ui, GetSystemLocalName(), true))
+		auto [locale, parentLocale] = GetSystemLocaleAndParent();
+		if (!LoadLanguageString(ui, locale, true))
 		{
-			if (!LoadLanguageString(ui, L"en-US", true))
-				return false;
+			if (!LoadLanguageString(ui, parentLocale, true))
+			{
+				if (!LoadLanguageString(ui, L"en-US", true))
+					return false;
+			}
 		}
-		else if(GetSystemLocalName() != L"en-US")
+		else if (locale != L"en-US")
+		{
 			LoadLanguageString(ui, L"en-US", true, false);
+		}
 
 		const HWND hWnd = (HWND)ctx->Base()->GetWindowHandle();
 		//SetWindowLongW(hWnd, GWL_STYLE, GetWindowLongW(hWnd, GWL_STYLE) & ~(WS_MAXIMIZEBOX | WS_SIZEBOX));

--- a/DWMBlurGlass/winmain.cpp
+++ b/DWMBlurGlass/winmain.cpp
@@ -40,8 +40,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		return 0;
 #endif
 
+	auto [locale, parentLocale] = MDWMBlurGlass::GetSystemLocaleAndParent();
+
 	if (!MDWMBlurGlass::LoadLanguageFileList() 
-		|| (!MDWMBlurGlass::LoadBaseLanguageString(MDWMBlurGlass::GetSystemLocalName())
+		|| (!MDWMBlurGlass::LoadBaseLanguageString(locale) && !MDWMBlurGlass::LoadBaseLanguageString(parentLocale)
 		&& !MDWMBlurGlass::LoadBaseLanguageString(L"en-US")))
 	{
 		MessageBoxW(nullptr, L"初始化失败: 没有有效的语言文件 (Initialization failed: No valid language file).", L"error", MB_ICONERROR);

--- a/Languagefiles/es.xml
+++ b/Languagefiles/es.xml
@@ -28,7 +28,7 @@
 	<loadfail>¡Error al cargar el componente!\nMensaje de error: </loadfail>
 	<saveconfig>Guardar configuración</saveconfig>
 	<effectset>Configuración de efectos</effectset>
-	<blurvalue>Radio de desenfoque (global):</blurvalue>
+	<blurvalue>Radio de desenfoque global:</blurvalue>
 	<overrideDwmapi>Redefinir efecto de DWMAPI (Win 11)</overrideDwmapi>
 	<extendborder>Extender efectos a bordes (Win 10)</extendborder>
 	<reflection>Habilitar efecto de reflejo Aero</reflection>
@@ -44,11 +44,11 @@
 	<preview>Vista previa</preview>
 	<sampletitle>Ejemplo de título de ventana (activa)</sampletitle>
 	<blurmethod>Método de desenfoque:</blurmethod>
-	<methodcustom>[Recomendado] Implementación personalizada de desenfoque que usa \nCVisual (DWM) y Windows.UI.Composition (dcomp) para lograr efectos \nde fondo personalizados, puede personalizar la mayoría de los parámetros, \nno sólo puede obtener la máxima eficiencia, sino también la mejor \napariencia y mayor estabilidad. Sin embargo, la compatibilidad no es tan \nbuena ya que puede fallar después de una importante actualización de \nWindows y deberá esperar una nueva versión del programa.</methodcustom>
-	<methodaccent>[No recomendado] Usa la implementación interna de desenfoque de DWM \nsin eliminar (clase AccentBlurBehind) para aplicar el efecto de desenfoque, \npuede personalizar algunos de los parámetros, pero es ineficiente y \nmenos estable. Puede funcionar normalmente en la mayoría de los \nsistemas, generalmente, una actualización del sistema no lo romperá.</methodaccent>
+	<methodcustom>[Recomendado] Implementación personalizada de desenfoque que usa \nCVisual (DWM) y Windows.UI.Composition (dcomp) para lograr efectos \nde fondo personalizados, puede personalizar la mayoría de los\nparámetros, no sólo puede obtener la máxima eficiencia, sino también \nla mejor apariencia y mayor estabilidad. Sin embargo, la compatibilidad \nno es tan buena ya que puede fallar después de una importante \nactualización de Windows y deberá esperar una nueva versión del \nprograma.</methodcustom>
+	<methodaccent>[No recomendado] Usa la implementación interna de desenfoque de \nDWM sin eliminar (clase AccentBlurBehind) para aplicar el efecto de \ndesenfoque, puede personalizar algunos de los parámetros, pero es \nineficiente y menos estable. Puede funcionar normalmente en la mayoría \nde los sistemas, generalmente, una actualización del sistema no lo \nromperá.</methodaccent>
 	<methoddwmapi>Usa DWMAPI documentado para aplicar el efecto SystemBackdrop \nlimitado, como Acrylic, Mica, no puede personalizar estos parámetros \nen absoluto. Aunque tenga alta eficiencia y mejor estabilidad, puede \nromper la apariencia de algunos programas y sólo está disponible \nen Windows 11 22H2 o superior.</methoddwmapi>
 	<effecttype>Tipo de efecto:</effecttype>
-	<blurvaluetitle>Radio de desenfoque (sólo barra de título):</blurvaluetitle>
+	<blurvaluetitle>Radio de desenfoque (barra de título):</blurvaluetitle>
 	<luminosity>Opacidad de luminosidad:</luminosity>
 	<colorBalance>ColorBalance:</colorBalance>
 	<blurBalance>BlurBalance:</blurBalance>

--- a/Languagefiles/es.xml
+++ b/Languagefiles/es.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<lang local="es-ES" author="Amaro Martínez (xoascf)">
+<lang local="es" author="Amaro Martínez (xoascf)">
 	<inituifail0>¡Error al inicializar la biblioteca MiaoUI!\nMensaje de error: </inituifail0>
 	<inituifail1>¡Error al crear el contexto de ventana!</inituifail1>
 	<inituifail2>¡Error al inicializar la ventana!</inituifail2>
@@ -29,11 +29,12 @@
 	<saveconfig>Guardar configuración</saveconfig>
 	<effectset>Configuración de efectos</effectset>
 	<blurvalue>Radio de desenfoque (global):</blurvalue>
-	<applyglobal>Redefinir efecto Mica establecido mediante DWMAPI (Win 11)</applyglobal>
+	<overrideDwmapi>Redefinir efecto de DWMAPI (Win 11)</overrideDwmapi>
 	<extendborder>Extender efectos a bordes (Win 10)</extendborder>
 	<reflection>Habilitar efecto de reflejo Aero</reflection>
 	<reflectiontip>(OldBlur sólo para Win 10)</reflectiontip>
 	<oldBtnSize>Restaurar tamaño de botones de barra de título (estilo de Win 7)</oldBtnSize>
+	<titlebtnGlow>Habilitar brillo de botones de barra de título (estilo de Win 7)</titlebtnGlow>
 	<cmodelight>Colores de modo claro</cmodelight>
 	<cmodedark>Colores de modo oscuro</cmodedark>
 	<blendcolor>Color fusión de barra de título (activa):</blendcolor>
@@ -58,6 +59,8 @@
 	<useaccentcolor>Usar color de énfasis para redefinir configuración de color</useaccentcolor>
 	<glassIntensity>Opacidad de textura de reflejo Aero:</glassIntensity>
 	<overrideAccent>Redefinir efecto AccentBlur</overrideAccent>
+	<scaleOptimizer>Habilitar optimización de renderizado de desenfoque</scaleOptimizer>
+	<disableOnBattery>Deshabilitar efecto en modo de ahorro de energía</disableOnBattery>
 	<symbolfile>Archivos de símbolos:</symbolfile>
 	<download>Descargar</download>
 	<symtip>Los archivos de símbolos (pdb) son archivos que registran información \nde depuración sobre un programa. Dado que los sistemas varían de una \nversión a otra, debe descargar los archivos de símbolos desde el servidor \nde Microsoft. Si actualiza su sistema, es posible que deba descargar los \narchivos de símbolos nuevamente.</symtip>


### PR DESCRIPTION
Implement a fallback mechanism to load the parent language translation if the specific locale translation is not found. Update the Spanish translation file to use the parent language ID code.